### PR TITLE
feat: 권한 설정 추가, 사용자 조회 구현, 필터 수정

### DIFF
--- a/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -17,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
@@ -38,9 +41,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(auth ->
-                        auth.anyRequest()
-                                .permitAll())
+        http.authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class)

--- a/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.sparta.outsourcing.domain.user.controller;
 
 import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.response.UserListResponse;
 import com.sparta.outsourcing.domain.user.dto.response.UserResponse;
 import com.sparta.outsourcing.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +22,21 @@ public class UserController {
 
     @GetMapping("/me")
     public ResponseEntity<UserResponse> getMe(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (userDetails == null) {
-            throw new RuntimeException();
-        }
-
         UserResponse userResponse = userService.findByEmail(userDetails.getEmail());
         return ResponseEntity.ok(userResponse);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponse> getUser(@PathVariable Long userId) {
+        UserResponse userResponse = userService.findById(userId);
+        return ResponseEntity.ok(userResponse);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ResponseEntity<UserListResponse> getUsers() {
+        UserListResponse userListResponse = userService.findAll();
+        return ResponseEntity.ok(userListResponse);
     }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/CustomUserDetails.java
@@ -4,10 +4,13 @@ import com.sparta.outsourcing.domain.user.entity.Role;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Builder
 @Getter
@@ -19,8 +22,13 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> authorities = new ArrayDeque<>();
-        authorities.add((GrantedAuthority) () -> role.name());
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(role.name()));
+
+        if (role == Role.ROLE_ADMIN || role == Role.ROLE_OWNER) {
+            authorities.add(new SimpleGrantedAuthority(Role.ROLE_USER.name()));
+        }
+
         return authorities;
     }
 

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/request/JoinRequest.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/request/JoinRequest.java
@@ -9,5 +9,6 @@ public class JoinRequest {
     private String phone;
     private String name;
     private String currentAddress;
-
+    private String adminToken;
+    private Boolean isOwner;
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserListResponse.java
@@ -1,0 +1,12 @@
+package com.sparta.outsourcing.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class UserListResponse {
+    List<UserResponse> userResponseList;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserResponse.java
@@ -6,17 +6,27 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Builder(access = AccessLevel.PROTECTED)
 @Getter
 public class UserResponse {
     private String email;
     private String createdDate;
+    private String name;
+    private String currentAddress;
+    private String phone;
+    private String role;
 
     public static UserResponse from(User user) {
         return UserResponse.builder()
                 .email(user.getEmail())
                 .createdDate(user.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")))
+                .name(user.getName())
+                .currentAddress(user.getCurrentAddress())
+                .phone(user.getPhone())
+                .role(user.getRole().name())
                 .build();
     }
+
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/Role.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/Role.java
@@ -1,5 +1,5 @@
 package com.sparta.outsourcing.domain.user.entity;
 
 public enum Role {
-    ROLE_ADMIN, ROLE_USER
+    ROLE_ADMIN ,ROLE_OWNER ,ROLE_USER
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
@@ -27,6 +27,9 @@ public class AuthService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
+    //TODO: 환경 변수에서 읽어오게 할 것
+    private final String ADMIN_TOKEN = "AAABnvxRVklrnYxKZ0aHgTBcXukeZygoC";
+
     @Transactional
     public JoinResponse join(JoinRequest joinRequest) {
         String email = joinRequest.getEmail();
@@ -36,8 +39,17 @@ public class AuthService {
         String currentAddress = joinRequest.getCurrentAddress();
         Role role = Role.ROLE_USER;
 
+
         if (userRepository.existsByEmail(email)) {
             throw new RuntimeException("중복된 사용자가 존재합니다");
+        }
+
+        if (isValidAdminToken(joinRequest.getAdminToken())) {
+            role = Role.ROLE_ADMIN;
+        }
+
+        if (joinRequest.getIsOwner()) {
+            role = Role.ROLE_OWNER;
         }
 
         User user = User.builder()
@@ -75,4 +87,7 @@ public class AuthService {
         return LoginResponse.builder().token(token).name(user.getName()).build();
     }
 
+    public boolean isValidAdminToken(String adminToken) {
+        return adminToken != null && adminToken.equals(ADMIN_TOKEN);
+    }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
             role = Role.ROLE_ADMIN;
         }
 
-        if (joinRequest.getIsOwner()) {
+        if (joinRequest.getIsOwner()!= null && joinRequest.getIsOwner()) {
             role = Role.ROLE_OWNER;
         }
 

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.sparta.outsourcing.domain.user.service;
 
+import com.sparta.outsourcing.domain.user.dto.response.UserListResponse;
 import com.sparta.outsourcing.domain.user.dto.response.UserResponse;
 import com.sparta.outsourcing.domain.user.entity.User;
 import com.sparta.outsourcing.domain.user.exception.UserNotFoundException;
@@ -7,6 +8,9 @@ import com.sparta.outsourcing.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,5 +22,20 @@ public class UserService {
     public UserResponse findByEmail(String email) {
         User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
         return UserResponse.from(user);
+    }
+
+    public UserResponse findById(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        return UserResponse.from(user);
+    }
+
+    public UserListResponse findAll() {
+        List<User> userList = userRepository.findAll();
+        List<UserResponse> userResponseList = new ArrayList<>();
+        for (User user : userList) {
+            UserResponse userResponse = UserResponse.from(user);
+            userResponseList.add(userResponse);
+        }
+        return UserListResponse.builder().userResponseList(userResponseList).build();
     }
 }

--- a/src/main/java/com/sparta/outsourcing/jwt/JwtFilter.java
+++ b/src/main/java/com/sparta/outsourcing/jwt/JwtFilter.java
@@ -30,14 +30,16 @@ public class JwtFilter extends OncePerRequestFilter {
         String tokenValue = jwtUtil.getTokenFromRequest(request);
 
         if (!StringUtils.hasText(tokenValue)) {
-            setErrorResponse(response, ErrorCode.TOKEN_NOT_FOUND);
+            log.info("TOKEN_NULL");
+            filterChain.doFilter(request, response);
             return;
         }
 
         String token = jwtUtil.substringToken(tokenValue);
 
         if (!jwtUtil.validateToken(token)) {
-            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+            log.info("TOKEN_INVALID");
+            filterChain.doFilter(request, response);
             return;
         }
 
@@ -48,34 +50,39 @@ public class JwtFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
-
     }
 
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String path = request.getRequestURI();
-        return path.equals("/login") || path.equals("/") || path.equals("/join") || path.startsWith("/stores") || path.startsWith("/reviews") || path.startsWith("/orders");
-    }
+//    @Override
+//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+//        String path = request.getRequestURI();
+//        return path.equals("/login") ||
+//                path.equals("/") ||
+//                path.equals("/join") ||
+//                path.startsWith("/stores") ||
+//                path.startsWith("/reviews") ||
+//                path.startsWith("/orders") ||
+//                path.startsWith("/users/") && !path.equals("/users/me");
+//    }
 
-    private void setErrorResponse(
-            HttpServletResponse response,
-            ErrorCode errorCode
-    ) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding("UTF-8");
-        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
-        try {
-            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @Data
-    public static class ErrorResponse {
-        private final Integer code;
-        private final String message;
-    }
+//    private void setErrorResponse(
+//            HttpServletResponse response,
+//            ErrorCode errorCode
+//    ) {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        response.setStatus(errorCode.getHttpStatus().value());
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        response.setCharacterEncoding("UTF-8");
+//        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
+//        try {
+//            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    @Data
+//    public static class ErrorResponse {
+//        private final Integer code;
+//        private final String message;
+//    }
 }


### PR DESCRIPTION
* 이제 모든 요청이 `JwtFilter` 를 거쳐갑니다.
  * 올바른 토큰이 주어지지 않았을 경우 `CustomUserDetails` 에 `null` 과 함께 인증되지 않았다는 정보가 담깁니다.
    * 현재 `SecurityConfig` 에서 모든 요청을 허용해서 `null` 이 담기는 것이며, 추후 인증을 거칠 `url` 을 설정할 시 null 이 담기는 것이 아닌, `403 Forbidden` 이 반환됩니다.
* 권한 `ROLE_ADMIN` , `ROLE_OWNER` 가 구현되었습니다. 사용하실 때에 `@PreAuthorize` 를 `controller` 메서드 위에 붙이시면 됩니다.
  * ex) `@PreAuthorize("hasRole('OWNER')")`