### PR TITLE
feat: 다중 토큰 발급과 재발급 구현 및 예외 정의, 테스트코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -44,6 +45,10 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // Redis
+    implementation("org.redisson:redisson-spring-boot-starter:3.16.4")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/outsourcing/advice/ControllerAdvice.java
+++ b/src/main/java/com/sparta/outsourcing/advice/ControllerAdvice.java
@@ -1,7 +1,0 @@
-package com.sparta.outsourcing.advice;
-
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-@RestControllerAdvice
-public class ControllerAdvice {
-}

--- a/src/main/java/com/sparta/outsourcing/config/RedisConfig.java
+++ b/src/main/java/com/sparta/outsourcing/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.sparta.outsourcing.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    RedissonClient redissonClient() {
+        Config config = new Config();
+        String address = "redis://" + host + ":" + port;
+        config.useSingleServer().setAddress(address);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
@@ -1,13 +1,10 @@
 package com.sparta.outsourcing.config;
 
-import com.sparta.outsourcing.jwt.JwtFilter;
-import com.sparta.outsourcing.jwt.JwtUtil;
-import com.sparta.outsourcing.jwt.LoginFilter;
+import com.sparta.outsourcing.jwt.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -23,10 +21,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtUtil jwtUtil) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtUtil jwtUtil, RefreshTokenService refreshTokenService) {
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshTokenService;
     }
 
     @Bean
@@ -43,10 +43,12 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll())
+//                        .requestMatchers("/reissue").permitAll())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class)
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshTokenService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenService), LogoutFilter.class)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();

--- a/src/main/java/com/sparta/outsourcing/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/controller/AuthController.java
@@ -1,16 +1,18 @@
 package com.sparta.outsourcing.domain.user.controller;
 
+import com.sparta.outsourcing.domain.user.dto.TokenDto;
 import com.sparta.outsourcing.domain.user.dto.request.JoinRequest;
-import com.sparta.outsourcing.domain.user.dto.request.LoginRequest;
-import com.sparta.outsourcing.domain.user.dto.response.JoinResponse;
-import com.sparta.outsourcing.domain.user.dto.response.LoginResponse;
+import com.sparta.outsourcing.domain.user.dto.response.TokenResponse;
+import com.sparta.outsourcing.domain.user.exception.TokenNotFoundException;
 import com.sparta.outsourcing.domain.user.service.AuthService;
+import com.sparta.outsourcing.jwt.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping
 @RequiredArgsConstructor
@@ -18,16 +20,49 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/join")
-    public ResponseEntity<JoinResponse> joinUser(@RequestBody JoinRequest joinRequest) {
-        JoinResponse joinResponse = authService.join(joinRequest);
-        return ResponseEntity.ok(joinResponse);
+    public ResponseEntity<TokenResponse> joinUser(@Valid @RequestBody JoinRequest joinRequest) {
+        TokenResponse tokenResponse = authService.join(joinRequest);
+        return ResponseEntity.ok(tokenResponse);
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
-        LoginResponse loginResponse = authService.login(loginRequest);
-        return ResponseEntity.ok(loginResponse);
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(HttpServletRequest request, HttpServletResponse response) {
+        TokenDto tokenDto = null;
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new TokenNotFoundException();
+        }
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                tokenDto = authService.reissueAccessToken(cookie.getValue());
+            }
+        }
+
+        if (tokenDto == null) {
+            throw new TokenNotFoundException();
+        }
+
+        jwtUtil.addJwtToHeader(tokenDto.getAccessToken(), response);
+        response.addCookie(createCooke("refresh", tokenDto.getRefreshToken()));
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .accessToken(tokenDto.getAccessToken())
+                .refreshToken(tokenDto.getRefreshToken())
+                .build();
+
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    public Cookie createCooke(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
@@ -1,17 +1,17 @@
 package com.sparta.outsourcing.domain.user.controller;
 
 import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.request.WithdrawRequest;
 import com.sparta.outsourcing.domain.user.dto.response.UserListResponse;
 import com.sparta.outsourcing.domain.user.dto.response.UserResponse;
 import com.sparta.outsourcing.domain.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -38,5 +38,21 @@ public class UserController {
     public ResponseEntity<UserListResponse> getUsers() {
         UserListResponse userListResponse = userService.findAll();
         return ResponseEntity.ok(userListResponse);
+    }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@RequestBody WithdrawRequest withdrawRequest,
+                                         @AuthenticationPrincipal CustomUserDetails userDetails,
+                                         HttpServletResponse response) {
+
+        userService.withDraw(withdrawRequest, userDetails);
+
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/request/JoinRequest.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/request/JoinRequest.java
@@ -1,12 +1,27 @@
 package com.sparta.outsourcing.domain.user.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class JoinRequest {
+
+    @NotBlank(message = "사용자 아이디는 이메일 형식이어야 합니다.")
+    @Email(message = "유효한 이메일 주소를 입력하세요.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8글자 이상이어야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "비밀번호는 대소문자 포함 영문 + 숫자 + 특수문자를 최소 1글자씩 포함해야 합니다.")
     private String password;
+
     private String phone;
+
     private String name;
     private String currentAddress;
     private String adminToken;

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.outsourcing.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class WithdrawRequest {
+    private String password;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/TokenResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class JoinResponse {
-    private String token;
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-@Builder(access = AccessLevel.PROTECTED)
+@Builder
 @Getter
 public class UserResponse {
     private String email;

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
@@ -7,15 +7,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@SQLDelete(sql = "UPDATE user SET status = 'WITHDRAWN' WHERE id = ?")
-@Where(clause = "status != 'WITHDRAWN'")
+@SQLDelete(sql = "UPDATE user SET status = 'WITHDRAWN' WHERE user_id = ?")
+@SQLRestriction("status != 'WITHDRAWN'")
 @Entity
 public class User {
 

--- a/src/main/java/com/sparta/outsourcing/domain/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.exception;
+
+import com.sparta.outsourcing.exception.BadRequestException;
+
+public class DuplicateUserException extends BadRequestException {
+    private static final String MESSAGE = "중복된 사용자가 존재합니다.";
+
+    public DuplicateUserException() {super(MESSAGE);}
+
+    public DuplicateUserException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/exception/InvalidPasswordException.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/exception/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.exception;
+
+import com.sparta.outsourcing.exception.BadRequestException;
+
+public class InvalidPasswordException extends BadRequestException {
+    private static final String MESSAGE = "비밀번호가 일치하지 않습니다.";
+
+    public InvalidPasswordException() {super(MESSAGE);}
+
+    public InvalidPasswordException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/exception/InvalidTokenException.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.exception;
+
+import com.sparta.outsourcing.exception.BadRequestException;
+
+public class InvalidTokenException extends BadRequestException {
+    private static final String MESSAGE = "올바르지 않은 토큰입니다.";
+
+    public InvalidTokenException() {super(MESSAGE);}
+
+    public InvalidTokenException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/exception/TokenNotFoundException.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/exception/TokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.exception;
+
+import com.sparta.outsourcing.exception.BadRequestException;
+
+public class TokenNotFoundException extends BadRequestException {
+    private static final String MESSAGE = "토큰이 존재하지 않습니다.";
+
+    public TokenNotFoundException() {super(MESSAGE);}
+
+    public TokenNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/exception/WithdrawnUserException.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/exception/WithdrawnUserException.java
@@ -1,0 +1,11 @@
+package com.sparta.outsourcing.domain.user.exception;
+
+import com.sparta.outsourcing.exception.BadRequestException;
+
+public class WithdrawnUserException extends BadRequestException {
+    private static final String MESSAGE = "탈퇴한 사용자입니다.";
+
+    public WithdrawnUserException() {super(MESSAGE);}
+
+    public WithdrawnUserException(String message) {super(message);}
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/repository/UserRepository.java
@@ -3,7 +3,9 @@ package com.sparta.outsourcing.domain.user.repository;
 import com.sparta.outsourcing.domain.user.entity.Status;
 import com.sparta.outsourcing.domain.user.entity.User;
 import com.sparta.outsourcing.domain.user.exception.UserNotFoundException;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -21,4 +23,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     default User findByIdOrElseThrow(Long userId) {
         return findById(userId).orElseThrow(UserNotFoundException::new);
     }
+
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailIncludingWithdrawn(@Param("email") String email);
+
+
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
@@ -1,22 +1,28 @@
 package com.sparta.outsourcing.domain.user.service;
 
 import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.TokenDto;
 import com.sparta.outsourcing.domain.user.dto.request.JoinRequest;
-import com.sparta.outsourcing.domain.user.dto.request.LoginRequest;
-import com.sparta.outsourcing.domain.user.dto.response.JoinResponse;
-import com.sparta.outsourcing.domain.user.dto.response.LoginResponse;
+import com.sparta.outsourcing.domain.user.dto.response.TokenResponse;
 import com.sparta.outsourcing.domain.user.entity.Grade;
 import com.sparta.outsourcing.domain.user.entity.Role;
 import com.sparta.outsourcing.domain.user.entity.Status;
 import com.sparta.outsourcing.domain.user.entity.User;
+import com.sparta.outsourcing.domain.user.exception.DuplicateUserException;
+import com.sparta.outsourcing.domain.user.exception.InvalidTokenException;
+import com.sparta.outsourcing.domain.user.exception.WithdrawnUserException;
 import com.sparta.outsourcing.domain.user.repository.UserRepository;
 import com.sparta.outsourcing.jwt.JwtUtil;
+import com.sparta.outsourcing.jwt.RefreshTokenService;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,12 +32,13 @@ public class AuthService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
     //TODO: 환경 변수에서 읽어오게 할 것
     private final String ADMIN_TOKEN = "AAABnvxRVklrnYxKZ0aHgTBcXukeZygoC";
 
     @Transactional
-    public JoinResponse join(JoinRequest joinRequest) {
+    public TokenResponse join(JoinRequest joinRequest) {
         String email = joinRequest.getEmail();
         String password = passwordEncoder.encode(joinRequest.getPassword());
         String name = joinRequest.getName();
@@ -39,9 +46,12 @@ public class AuthService {
         String currentAddress = joinRequest.getCurrentAddress();
         Role role = Role.ROLE_USER;
 
-
-        if (userRepository.existsByEmail(email)) {
-            throw new RuntimeException("중복된 사용자가 존재합니다");
+        Optional<User> optionalUser = userRepository.findByEmailIncludingWithdrawn(email);
+        if (optionalUser.isPresent()) {
+            if (optionalUser.get().getStatus() == Status.WITHDRAWN) {
+                throw new WithdrawnUserException("탈퇴한 사용자의 아이디는 재사용할 수 없습니다.");
+            }
+            throw new DuplicateUserException();
         }
 
         if (isValidAdminToken(joinRequest.getAdminToken())) {
@@ -67,24 +77,61 @@ public class AuthService {
 
         userRepository.save(user);
 
-        String token = jwtUtil.createToken(
-                CustomUserDetails.builder()
-                        .email(email)
-                        .build(), role.name());
+        CustomUserDetails customUserDetails = CustomUserDetails.builder()
+                .email(email)
+                .role(role)
+                .build();
 
-        return JoinResponse.builder().token(token).build();
+        String refreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role.name(), 86400000L);
+        String refreshToken = jwtUtil.substringToken(refreshTokenBearer);
+        String token = jwtUtil.createToken("access", customUserDetails, role.name(), 600000L);
+
+        return TokenResponse.builder()
+                .accessToken(token)
+                .refreshToken(refreshToken)
+                .build();
     }
 
-    public LoginResponse login(LoginRequest loginRequest) {
-        User user = userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(RuntimeException::new);
-        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+    public TokenDto reissueAccessToken(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new InvalidTokenException();
         }
 
-        String token = jwtUtil.createToken(CustomUserDetails.builder()
-                .email(user.getEmail())
-                .build(), user.getRole().name());
-        return LoginResponse.builder().token(token).name(user.getName()).build();
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new InvalidTokenException("만료된 토큰입니다.");
+        }
+
+        String category = jwtUtil.getCategory(refreshToken);
+
+        if (!category.equals("refresh")) {
+            throw new InvalidTokenException();
+        }
+
+        CustomUserDetails customUserDetails = jwtUtil.getCustomUserDetailsFromToken(refreshToken);
+        String email = customUserDetails.getEmail();
+        String role = customUserDetails.getRole().name();
+
+        String storedRefreshToken = refreshTokenService.getRefreshToken(email);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            throw new InvalidTokenException();
+        }
+
+        String newRefreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role, 86400000L);
+        String newAccessToken = jwtUtil.createToken("access", customUserDetails, role, 600000L);
+
+        String newRefreshToken = jwtUtil.substringToken(newRefreshTokenBearer);
+
+        refreshTokenService.deleteRefreshToken(email);
+        refreshTokenService.saveRefreshToken(newRefreshToken, email, 24, TimeUnit.HOURS);
+
+        return TokenDto.builder()
+                .refreshToken(newRefreshToken)
+                .accessToken(newAccessToken)
+                .build();
     }
 
     public boolean isValidAdminToken(String adminToken) {

--- a/src/main/java/com/sparta/outsourcing/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/outsourcing/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,5 +45,23 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handlerGeneralException(Exception e) {
         log.error("Exception", e);
         return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder sb = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("](은)는 ");
+            sb.append(fieldError.getDefaultMessage());
+            sb.append(" 입력된 값: [");
+            sb.append(fieldError.getRejectedValue());
+            sb.append("]");
+        }
+
+        return new ResponseEntity<>(sb.toString(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/sparta/outsourcing/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/sparta/outsourcing/jwt/CustomLogoutFilter.java
@@ -1,0 +1,91 @@
+package com.sparta.outsourcing.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+    public CustomLogoutFilter(JwtUtil jwtUtil, RefreshTokenService refreshTokenService) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refreshToken = cookie.getValue();
+            }
+        }
+
+        if (refreshToken == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String category = jwtUtil.getCategory(refreshToken);
+        if (!category.equals("refresh")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String email = jwtUtil.getEmail(refreshToken);
+        if (!refreshTokenService.existsByEmail(email)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshTokenService.deleteRefreshToken(email);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/com/sparta/outsourcing/jwt/LoginFilter.java
+++ b/src/main/java/com/sparta/outsourcing/jwt/LoginFilter.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
 import com.sparta.outsourcing.domain.user.dto.request.LoginRequest;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -15,24 +17,29 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+    private final RefreshTokenService refreshTokenService;
 
-    public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+    public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil, RefreshTokenService refreshTokenService) {
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
+        this.objectMapper = new ObjectMapper();
+        this.refreshTokenService = refreshTokenService;
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             LoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
             String username = loginRequest.getEmail();
             String password = loginRequest.getPassword();
@@ -51,15 +58,34 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority();
+        String role = auth.getAuthority(); // TODO: 어차피 customUserDetails 가 role 을 들고있기 때문에 필요 없음
 
-        String token = jwtUtil.createToken(customUserDetails, role);
+        String accessToken = jwtUtil.createToken("access", customUserDetails, role, 600000L);
+        String refreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role, 86400000L);
+        String refreshToken = jwtUtil.substringToken(refreshTokenBearer); // TODO: createToken 의 반환이 Bearer 를 포함하지 않도록 할 것
 
-        response.addHeader("Authorization", token);
+        response.setHeader("Authorization", accessToken);
+        response.addCookie(createCooke("refresh", refreshToken));
+
+        PrintWriter writer = response.getWriter();
+        writer.println("access token = " + accessToken);
+        writer.print("refresh token = " + refreshToken);
+
+        refreshTokenService.saveRefreshToken(refreshToken, customUserDetails.getEmail(), 24, TimeUnit.HOURS);
+
+        response.setStatus(HttpStatus.OK.value());
     }
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         response.setStatus(401);
+    }
+
+    public Cookie createCooke(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/sparta/outsourcing/jwt/RefreshTokenService.java
+++ b/src/main/java/com/sparta/outsourcing/jwt/RefreshTokenService.java
@@ -1,0 +1,35 @@
+package com.sparta.outsourcing.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+
+    private final RedissonClient redissonClient;
+
+    public void saveRefreshToken(String token, String email, long duration, TimeUnit unit) {
+        RBucket<String> bucket = redissonClient.getBucket("refreshToken:" + email);
+        bucket.set(token, duration, unit);  // Redis에 토큰을 저장하고 만료 시간을 설정
+    }
+
+    public String getRefreshToken(String email) {
+        RBucket<String> bucket = redissonClient.getBucket("refreshToken:" + email);
+        return bucket.get();
+    }
+
+    public void deleteRefreshToken(String email) {
+        RBucket<String> bucket = redissonClient.getBucket("refreshToken:" + email);
+        bucket.delete();
+    }
+
+    public boolean existsByEmail(String email) {
+        RBucket<Object> bucket = redissonClient.getBucket("refreshToken:" + email);
+        return bucket.isExists();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,7 @@ cloud.aws.credentials.secretKey=${aws_secretKey}
 cloud.aws.s3.bucketName=${aws_bucketName}
 cloud.aws.region.static=${aws_region}
 cloud.aws.stack.auto-=false
+
+## Redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379

--- a/src/test/java/com/sparta/outsourcing/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,138 @@
+package com.sparta.outsourcing.domain.user.controller;
+
+import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.request.WithdrawRequest;
+import com.sparta.outsourcing.domain.user.dto.response.UserListResponse;
+import com.sparta.outsourcing.domain.user.dto.response.UserResponse;
+import com.sparta.outsourcing.domain.user.entity.Role;
+import com.sparta.outsourcing.domain.user.service.UserService;
+import com.sparta.outsourcing.jwt.JwtUtil;
+import com.sparta.outsourcing.jwt.RefreshTokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @WithMockUser(username = "test@example.com", roles = {"USER"})
+    void getMe_success() throws Exception {
+        // Given
+        CustomUserDetails userDetails = CustomUserDetails.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        UserResponse userResponse = UserResponse.builder()
+                .email("test@example.com")
+                .name("John Doe")
+                .build();
+
+        when(userService.findByEmail(userDetails.getEmail())).thenReturn(userResponse);
+
+        // When & Then
+        mockMvc.perform(get("/users/me")
+                        .with(user(userDetails)))  // Authentication principal 설정
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.name").value("John Doe"));
+    }
+
+    @Test
+    @WithMockUser(username = "admin@example.com", roles = {"ADMIN"})
+    void getUser_asAdmin_success() throws Exception {
+        // Given
+        Long userId = 1L;
+        UserResponse userResponse = UserResponse.builder()
+                .email("testuser@example.com")
+                .name("Test User")
+                .build();
+
+        when(userService.findById(userId)).thenReturn(userResponse);
+
+        // When & Then
+        mockMvc.perform(get("/users/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("testuser@example.com"))
+                .andExpect(jsonPath("$.name").value("Test User"));
+    }
+
+    @Test
+    @WithMockUser(username = "admin@example.com", roles = {"ADMIN"})
+    void getUsers_asAdmin_success() throws Exception {
+        // Given
+        UserListResponse userListResponse = UserListResponse.builder()
+                .userResponseList(List.of(
+                        UserResponse.builder().email("user1@example.com").name("User One").build(),
+                        UserResponse.builder().email("user2@example.com").name("User Two").build()
+                ))
+                .build();
+
+        when(userService.findAll()).thenReturn(userListResponse);
+
+        // When & Then
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.users[0].email").value("user1@example.com"))
+                .andExpect(jsonPath("$.users[0].name").value("User One"))
+                .andExpect(jsonPath("$.users[1].email").value("user2@example.com"))
+                .andExpect(jsonPath("$.users[1].name").value("User Two"));
+    }
+
+    @Test
+    @WithMockUser(username = "test@example.com", roles = {"USER"})
+    void withdraw_success() throws Exception {
+        // Given
+        WithdrawRequest withdrawRequest = WithdrawRequest.builder()
+                .password("Password123!")
+                .build();
+
+        CustomUserDetails userDetails = CustomUserDetails.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        doNothing().when(userService).withDraw(any(WithdrawRequest.class), eq(userDetails));
+
+        // When & Then
+        mockMvc.perform(post("/users/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\": \"Password123!\"}")
+                        .with(user(userDetails)))
+                .andExpect(status().isNoContent());
+
+        verify(userService, times(1)).withDraw(any(WithdrawRequest.class), eq(userDetails));
+    }
+
+}

--- a/src/test/java/com/sparta/outsourcing/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,183 @@
+package com.sparta.outsourcing.domain.user.service;
+
+import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.TokenDto;
+import com.sparta.outsourcing.domain.user.dto.request.JoinRequest;
+import com.sparta.outsourcing.domain.user.dto.response.TokenResponse;
+import com.sparta.outsourcing.domain.user.entity.Role;
+import com.sparta.outsourcing.domain.user.entity.Status;
+import com.sparta.outsourcing.domain.user.entity.User;
+import com.sparta.outsourcing.domain.user.exception.DuplicateUserException;
+import com.sparta.outsourcing.domain.user.exception.InvalidTokenException;
+import com.sparta.outsourcing.domain.user.exception.WithdrawnUserException;
+import com.sparta.outsourcing.domain.user.repository.UserRepository;
+import com.sparta.outsourcing.jwt.JwtUtil;
+import com.sparta.outsourcing.jwt.RefreshTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @DisplayName("회원가입에 성공한다.")
+    @Test
+    void join_success() {
+        // Given
+        JoinRequest joinRequest = JoinRequest.builder()
+                .email("test@example.com")
+                .password("Password123!")
+                .name("John Doe")
+                .phone("010-1234-5678")
+                .currentAddress("Seoul")
+                .adminToken(null)
+                .isOwner(false)
+                .build();
+
+        when(userRepository.findByEmailIncludingWithdrawn(joinRequest.getEmail())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(joinRequest.getPassword())).thenReturn("encryptedPassword");
+        when(jwtUtil.createToken(eq("refresh"), any(CustomUserDetails.class), anyString(), anyLong()))
+                .thenReturn("Bearer refreshToken"); // refreshToken 반환
+        when(jwtUtil.createToken(eq("access"), any(CustomUserDetails.class), anyString(), anyLong()))
+                .thenReturn("Bearer accessToken"); // accessToken 반환
+        when(jwtUtil.substringToken(anyString())).thenReturn("refreshToken");
+
+        // When
+        TokenResponse tokenResponse = authService.join(joinRequest);
+
+        // Then
+        assertThat(tokenResponse.getAccessToken()).isEqualTo("Bearer accessToken");
+        assertThat(tokenResponse.getRefreshToken()).isEqualTo("refreshToken");
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @DisplayName("회원가입시 중복된 이메일일 경우 예외를 던진다.")
+    @Test
+    void join_duplicateEmail_throwsDuplicateUserException() {
+        // Given
+        JoinRequest joinRequest = JoinRequest.builder()
+                .email("test@example.com")
+                .password("password123")
+                .name("John Doe")
+                .phone("010-1234-5678")
+                .currentAddress("Seoul")
+                .build();
+
+        User user = User.builder()
+                .email("testuser@example.com")
+                .password("encodedPassword")
+                .name("Test User")
+                .createdDate(LocalDateTime.now())
+                .status(Status.NORMAL)
+                .role(Role.ROLE_USER)
+                .build();
+
+
+        when(userRepository.findByEmailIncludingWithdrawn(joinRequest.getEmail())).thenReturn(Optional.of(user));
+
+        // When & Then
+        assertThrows(DuplicateUserException.class, () -> authService.join(joinRequest));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @DisplayName("회원가입시 이미 탈퇴한 유저일 경우 예외를 던진다.")
+    @Test
+    void join_withdrawnUser_throwsWithdrawnUserException() {
+        // Given
+        JoinRequest joinRequest = JoinRequest.builder()
+                .email("test@example.com")
+                .password("password123")
+                .name("John Doe")
+                .phone("010-1234-5678")
+                .currentAddress("Seoul")
+                .build();
+
+        User user = User.builder()
+                .email("testuser@example.com")
+                .password("encodedPassword")
+                .name("Test User")
+                .createdDate(LocalDateTime.now())
+                .status(Status.WITHDRAWN)
+                .role(Role.ROLE_USER)
+                .build();
+
+        when(userRepository.findByEmailIncludingWithdrawn(joinRequest.getEmail())).thenReturn(Optional.of(user));
+
+        // When & Then
+        assertThrows(WithdrawnUserException.class, () -> authService.join(joinRequest));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @DisplayName("토큰 재발급에 성공한다.")
+    @Test
+    void reissueAccessToken_success() {
+        // Given
+        String refreshToken = "validRefreshToken";
+        CustomUserDetails customUserDetails = CustomUserDetails.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+
+        when(jwtUtil.getCategory(refreshToken)).thenReturn("refresh");
+        when(jwtUtil.getCustomUserDetailsFromToken(refreshToken)).thenReturn(customUserDetails);
+        when(refreshTokenService.getRefreshToken(customUserDetails.getEmail())).thenReturn("validRefreshToken");
+        when(jwtUtil.createToken(anyString(), any(CustomUserDetails.class), anyString(), anyLong()))
+                .thenReturn("Bearer newRefreshToken", "Bearer newAccessToken");
+        when(jwtUtil.substringToken(anyString())).thenReturn("newRefreshToken");
+
+        // When
+        TokenDto tokenDto = authService.reissueAccessToken(refreshToken);
+
+        // Then
+        assertThat(tokenDto.getAccessToken()).isEqualTo("Bearer newAccessToken");
+        assertThat(tokenDto.getRefreshToken()).isEqualTo("newRefreshToken");
+        verify(refreshTokenService, times(1)).deleteRefreshToken(customUserDetails.getEmail());
+        verify(refreshTokenService, times(1)).saveRefreshToken(anyString(), eq(customUserDetails.getEmail()), eq(24L), eq(TimeUnit.HOURS));
+    }
+
+    @DisplayName("토큰재발급시 잘못된 refresh 토큰일 경우 예외를 던진다.")
+    @Test
+    void reissueAccessToken_invalidRefreshToken_throwsInvalidTokenException() {
+        // Given
+        String refreshToken = "invalidRefreshToken";
+
+        when(jwtUtil.getCategory(refreshToken)).thenThrow(new InvalidTokenException());
+
+        // When & Then
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshToken))
+                .isInstanceOf(InvalidTokenException.class);
+
+        verify(refreshTokenService, never()).deleteRefreshToken(anyString());
+        verify(refreshTokenService, never()).saveRefreshToken(anyString(), anyString(), anyLong(), any());
+    }
+
+}

--- a/src/test/java/com/sparta/outsourcing/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/user/service/UserServiceTest.java
@@ -1,0 +1,162 @@
+package com.sparta.outsourcing.domain.user.service;
+
+import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
+import com.sparta.outsourcing.domain.user.dto.request.WithdrawRequest;
+import com.sparta.outsourcing.domain.user.dto.response.UserListResponse;
+import com.sparta.outsourcing.domain.user.dto.response.UserResponse;
+import com.sparta.outsourcing.domain.user.entity.Role;
+import com.sparta.outsourcing.domain.user.entity.Status;
+import com.sparta.outsourcing.domain.user.entity.User;
+import com.sparta.outsourcing.domain.user.exception.InvalidPasswordException;
+import com.sparta.outsourcing.domain.user.exception.UserNotFoundException;
+import com.sparta.outsourcing.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User user;
+    private CustomUserDetails customUserDetails;
+    private WithdrawRequest withdrawRequest;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("testuser@example.com")
+                .password("encodedPassword")
+                .name("Test User")
+                .createdDate(LocalDateTime.now())
+                .status(Status.NORMAL)
+                .role(Role.ROLE_USER)
+                .build();
+
+        customUserDetails = CustomUserDetails.builder()
+                .email("testuset@example.com").build();
+
+        withdrawRequest = WithdrawRequest.builder()
+                .password("rowPassword").build();
+    }
+
+    @DisplayName("이메일로 사용자 조회에 성공한다.")
+    @Test
+    void givenEmailWhenFindByEmailThenReturnsUserResponse() {
+        // Given
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+
+        // When
+        UserResponse result = userService.findByEmail("testuser@example.com");
+
+        // Then
+        assertThat(result.getEmail()).isEqualTo(user.getEmail());
+        verify(userRepository, times(1)).findByEmail(anyString());
+    }
+
+    @DisplayName("이메일로 없는 사용자를 조회시 예외를 반환한다.")
+    @Test
+    void givenEmailWhenFindByEmailThenThrowsException() {
+        // Given
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> userService.findByEmail("testuser@example.com"))
+                .isInstanceOf(UserNotFoundException.class);
+        verify(userRepository, times(1)).findByEmail(anyString());
+    }
+
+    @DisplayName("Id 로 사용자 조회에 성공한다.")
+    @Test
+    void givenIdWhenFindByIdThenReturnsUserResponse() {
+        // Given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+        // When
+        UserResponse result = userService.findById(1L);
+
+        // Then
+        assertThat(result.getEmail()).isEqualTo(user.getEmail());
+        verify(userRepository, times(1)).findById(anyLong());
+    }
+
+    @DisplayName("Id로 없는 사용자를 조회시 예외를 반환한다.")
+    @Test
+    void findById_userNotFound() {
+        // Given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // When/Then
+        assertThatThrownBy(() -> userService.findById(1L))
+                .isInstanceOf(UserNotFoundException.class);
+        verify(userRepository, times(1)).findById(anyLong());
+    }
+
+    @DisplayName("모든 사용자 조회에 성공한다.")
+    @Test
+    void findAll_success() {
+        // Given
+        List<User> users = new ArrayList<>();
+        users.add(user);
+        when(userRepository.findAll()).thenReturn(users);
+
+        // When
+        UserListResponse result = userService.findAll();
+
+        // Then
+        assertThat(result.getUserResponseList()).hasSize(1);
+        verify(userRepository, times(1)).findAll();
+    }
+
+    @DisplayName("회원탈퇴에 성공한다")
+    @Test
+    void withDraw_success() {
+        // Given
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+
+        // When
+        userService.withDraw(withdrawRequest, customUserDetails);
+
+        // Then
+        verify(userRepository, times(1)).delete(user);  // 사용자가 성공적으로 삭제되는지 확인
+    }
+
+    @DisplayName("회원탈퇴시 비밀번호가 일치하지 않으면 예외를 반환한다.")
+    @Test
+    void withDraw_invalidPassword() {
+        // Given
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);  // 비밀번호 불일치
+
+        // When & Then
+        assertThrows(InvalidPasswordException.class, () -> userService.withDraw(withdrawRequest, customUserDetails));
+
+        verify(userRepository, never()).delete(any());  // 비밀번호가 틀리면 삭제되지 않음
+    }
+
+}

--- a/src/test/java/com/sparta/outsourcing/jwt/RefreshTokenServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/jwt/RefreshTokenServiceTest.java
@@ -1,0 +1,107 @@
+package com.sparta.outsourcing.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RBucket<String> bucket;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    void saveRefreshToken_success() {
+        // Given
+        String token = "refreshToken123";
+        String email = "test@example.com";
+        long duration = 24L;
+        TimeUnit unit = TimeUnit.HOURS;
+
+        when(redissonClient.<String>getBucket("refreshToken:" + email)).thenReturn(bucket);
+
+        // When
+        refreshTokenService.saveRefreshToken(token, email, duration, unit);
+
+        // Then
+        verify(bucket, times(1)).set(token, duration, unit);
+    }
+
+    @Test
+    void getRefreshToken_success() {
+        // Given
+        String email = "test@example.com";
+        String expectedToken = "refreshToken123";
+
+        when(redissonClient.<String>getBucket("refreshToken:" + email)).thenReturn(bucket);
+        when(bucket.get()).thenReturn(expectedToken);
+
+        // When
+        String actualToken = refreshTokenService.getRefreshToken(email);
+
+        // Then
+        assertThat(actualToken).isEqualTo(expectedToken);
+    }
+
+    @Test
+    void deleteRefreshToken_success() {
+        // Given
+        String email = "test@example.com";
+
+        when(redissonClient.<String>getBucket("refreshToken:" + email)).thenReturn(bucket);
+
+        // When
+        refreshTokenService.deleteRefreshToken(email);
+
+        // Then
+        verify(bucket, times(1)).delete();
+    }
+
+    @Test
+    void existsByEmail_success() {
+        // Given
+        String email = "test@example.com";
+
+        when(redissonClient.<String>getBucket("refreshToken:" + email)).thenReturn(bucket);
+        when(bucket.isExists()).thenReturn(true);
+
+        // When
+        boolean exists = refreshTokenService.existsByEmail(email);
+
+        // Then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByEmail_notFound() {
+        // Given
+        String email = "test@example.com";
+
+        when(redissonClient.<String>getBucket("refreshToken:" + email)).thenReturn(bucket);
+        when(bucket.isExists()).thenReturn(false);
+
+        // When
+        boolean exists = refreshTokenService.existsByEmail(email);
+
+        // Then
+        assertThat(exists).isFalse();
+    }
+}


### PR DESCRIPTION
* 다중 토큰 발급을 구현했습니다.
  * `refresh token` 을 저장하기 위해서 `redis` 의존성을 추가했습니다.
  * 이제 토큰 만료시 401 에러코드가 반환됩니다.
* 토큰 재발급 요청시 `access token` 과 `refresh token` 이 재발급됩니다.
* 회원가입시 입력값의 검증을 추가했습니다.
* 회원 탈퇴를 구현했습니다.
  * 회원 탈퇴시 모든 토큰이 만료되며 `user` 의 `status` 가 `WITHDRAWN` 으로 변경됩니다.
* 각 `Service` 들과 `UserController` 의  테스트코드를 작성했습니다.