### PR TITLE
refacor: `createToken()` - `enum` 사용으로 코드 가독성 및 유지보수성 향상

### DIFF
--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/TokenType.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/TokenType.java
@@ -1,0 +1,16 @@
+package com.sparta.outsourcing.domain.user.entity;
+
+public enum TokenType {
+    ACCESS(600000L), // 10분
+    REFRESH(86400000L); // 1일
+
+    private final long expireMs;
+
+    TokenType(long expireMs) {
+        this.expireMs = expireMs;
+    }
+
+    public long getExpireMs() {
+        return expireMs;
+    }
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/AuthService.java
@@ -4,10 +4,7 @@ import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
 import com.sparta.outsourcing.domain.user.dto.TokenDto;
 import com.sparta.outsourcing.domain.user.dto.request.JoinRequest;
 import com.sparta.outsourcing.domain.user.dto.response.TokenResponse;
-import com.sparta.outsourcing.domain.user.entity.Grade;
-import com.sparta.outsourcing.domain.user.entity.Role;
-import com.sparta.outsourcing.domain.user.entity.Status;
-import com.sparta.outsourcing.domain.user.entity.User;
+import com.sparta.outsourcing.domain.user.entity.*;
 import com.sparta.outsourcing.domain.user.exception.DuplicateUserException;
 import com.sparta.outsourcing.domain.user.exception.InvalidTokenException;
 import com.sparta.outsourcing.domain.user.exception.WithdrawnUserException;
@@ -82,12 +79,11 @@ public class AuthService {
                 .role(role)
                 .build();
 
-        String refreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role.name(), 86400000L);
-        String refreshToken = jwtUtil.substringToken(refreshTokenBearer);
-        String token = jwtUtil.createToken("access", customUserDetails, role.name(), 600000L);
+        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, customUserDetails);
+        String accessToken = jwtUtil.createToken(TokenType.ACCESS, customUserDetails);
 
         return TokenResponse.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
@@ -112,7 +108,6 @@ public class AuthService {
 
         CustomUserDetails customUserDetails = jwtUtil.getCustomUserDetailsFromToken(refreshToken);
         String email = customUserDetails.getEmail();
-        String role = customUserDetails.getRole().name();
 
         String storedRefreshToken = refreshTokenService.getRefreshToken(email);
 
@@ -120,10 +115,9 @@ public class AuthService {
             throw new InvalidTokenException();
         }
 
-        String newRefreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role, 86400000L);
-        String newAccessToken = jwtUtil.createToken("access", customUserDetails, role, 600000L);
+        String newRefreshToken = jwtUtil.createToken(TokenType.REFRESH, customUserDetails);
+        String newAccessToken = jwtUtil.createToken(TokenType.ACCESS, customUserDetails);
 
-        String newRefreshToken = jwtUtil.substringToken(newRefreshTokenBearer);
 
         refreshTokenService.deleteRefreshToken(email);
         refreshTokenService.saveRefreshToken(newRefreshToken, email, 24, TimeUnit.HOURS);

--- a/src/main/java/com/sparta/outsourcing/jwt/LoginFilter.java
+++ b/src/main/java/com/sparta/outsourcing/jwt/LoginFilter.java
@@ -3,6 +3,7 @@ package com.sparta.outsourcing.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.outsourcing.domain.user.dto.CustomUserDetails;
 import com.sparta.outsourcing.domain.user.dto.request.LoginRequest;
+import com.sparta.outsourcing.domain.user.entity.TokenType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -55,14 +56,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority(); // TODO: 어차피 customUserDetails 가 role 을 들고있기 때문에 필요 없음
-
-        String accessToken = jwtUtil.createToken("access", customUserDetails, role, 600000L);
-        String refreshTokenBearer = jwtUtil.createToken("refresh", customUserDetails, role, 86400000L);
-        String refreshToken = jwtUtil.substringToken(refreshTokenBearer); // TODO: createToken 의 반환이 Bearer 를 포함하지 않도록 할 것
+        String accessToken = jwtUtil.createToken(TokenType.ACCESS, customUserDetails);
+        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, customUserDetails);
 
         response.setHeader("Authorization", accessToken);
         response.addCookie(createCooke("refresh", refreshToken));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,6 @@ cloud.aws.s3.bucketName=${aws_bucketName}
 cloud.aws.region.static=${aws_region}
 cloud.aws.stack.auto-=false
 
-## Redis
+# Redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379

--- a/src/test/java/com/sparta/outsourcing/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.sparta.outsourcing.jwt.RefreshTokenService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -29,8 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(UserController.class)
 class UserControllerTest {
 
     @Autowired
@@ -44,6 +44,7 @@ class UserControllerTest {
 
     @MockBean
     private RefreshTokenService refreshTokenService;
+
 
     @Test
     @WithMockUser(username = "test@example.com", roles = {"USER"})

--- a/src/test/java/com/sparta/outsourcing/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/outsourcing/domain/user/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.sparta.outsourcing.domain.user.dto.request.JoinRequest;
 import com.sparta.outsourcing.domain.user.dto.response.TokenResponse;
 import com.sparta.outsourcing.domain.user.entity.Role;
 import com.sparta.outsourcing.domain.user.entity.Status;
+import com.sparta.outsourcing.domain.user.entity.TokenType;
 import com.sparta.outsourcing.domain.user.entity.User;
 import com.sparta.outsourcing.domain.user.exception.DuplicateUserException;
 import com.sparta.outsourcing.domain.user.exception.InvalidTokenException;
@@ -65,11 +66,10 @@ class AuthServiceTest {
 
         when(userRepository.findByEmailIncludingWithdrawn(joinRequest.getEmail())).thenReturn(Optional.empty());
         when(passwordEncoder.encode(joinRequest.getPassword())).thenReturn("encryptedPassword");
-        when(jwtUtil.createToken(eq("refresh"), any(CustomUserDetails.class), anyString(), anyLong()))
-                .thenReturn("Bearer refreshToken"); // refreshToken 반환
-        when(jwtUtil.createToken(eq("access"), any(CustomUserDetails.class), anyString(), anyLong()))
+        when(jwtUtil.createToken(any(TokenType.class), any(CustomUserDetails.class)))
+                .thenReturn("refreshToken"); // refreshToken 반환
+        when(jwtUtil.createToken(any(TokenType.class), any(CustomUserDetails.class)))
                 .thenReturn("Bearer accessToken"); // accessToken 반환
-        when(jwtUtil.substringToken(anyString())).thenReturn("refreshToken");
 
         // When
         TokenResponse tokenResponse = authService.join(joinRequest);
@@ -150,9 +150,8 @@ class AuthServiceTest {
         when(jwtUtil.getCategory(refreshToken)).thenReturn("refresh");
         when(jwtUtil.getCustomUserDetailsFromToken(refreshToken)).thenReturn(customUserDetails);
         when(refreshTokenService.getRefreshToken(customUserDetails.getEmail())).thenReturn("validRefreshToken");
-        when(jwtUtil.createToken(anyString(), any(CustomUserDetails.class), anyString(), anyLong()))
-                .thenReturn("Bearer newRefreshToken", "Bearer newAccessToken");
-        when(jwtUtil.substringToken(anyString())).thenReturn("newRefreshToken");
+        when(jwtUtil.createToken(any(TokenType.class), any(CustomUserDetails.class)))
+                .thenReturn("newRefreshToken", "Bearer newAccessToken");
 
         // When
         TokenDto tokenDto = authService.reissueAccessToken(refreshToken);


### PR DESCRIPTION
* createToken 메소드에서 문자열 리터럴 대신 Token enum을 사용하여 토큰 카테고리를 관리하도록 리팩토링했습니다.
* 토큰의 만료 시간을 enum 내에 정의하여 코드의 가독성을 높이고, 하드코딩된 값을 제거했습니다.
* createToken 메소드의 반환값이 BEARER_PREFIX를 붙일지 여부를 결정하는 로직을 추가했습니다.